### PR TITLE
Install arbitrary packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,8 @@ script:
   # build as a Go program
   - make r2pm
   - ./r2pm init
+  # r2dec must be present in the database
+  - ./r2pm search dec 2>&1 | grep -q Decompiler
+  - ./r2pm install -f test/test.yaml
+  - ./r2pm list installed 2>&1 | grep -q test
   - ./r2pm delete
-  # - ./r2pm -s r2dec | grep -c Decompiler

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -38,6 +38,15 @@ func Install(r2pmDir, packageName string) error {
 	return s.InstallPackage(packageName)
 }
 
+func InstallFromFile(r2pmDir, path string) error {
+	s, err := site.New(r2pmDir)
+	if err != nil {
+		return xerrors.Errorf(msgCannotInitialize, err)
+	}
+
+	return s.InstallPackageFromFile(path)
+}
+
 func ListAvailable(r2pmDir string) ([]r2package.Info, error) {
 	s, err := site.New(r2pmDir)
 	if err != nil {

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -71,7 +71,7 @@ func Search(r2pmDir, pattern string) ([]r2package.Info, error) {
 		return nil, xerrors.Errorf("%q is not a valid regex: %w", pattern, err)
 	}
 
-	packages, err := ListInstalled(r2pmDir)
+	packages, err := ListAvailable(r2pmDir)
 	if err != nil {
 		return nil, xerrors.Errorf("could not get the list of packages: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -81,8 +81,19 @@ func main() {
 		{
 			Name:      "install",
 			Usage:     "install a package",
-			ArgsUsage: "PACKAGE",
+			ArgsUsage: "[PACKAGE]",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "f",
+					Usage: "install a package described by a local file",
+				},
+			},
 			Action: func(c *cli.Context) error {
+				if path := c.String("f"); path != "" {
+					log.Print("Installing " + path)
+					return features.InstallFromFile(r2pmDir, path)
+				}
+
 				packageName := getArgumentOrExit(c)
 
 				return features.Install(r2pmDir, packageName)

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -1,0 +1,11 @@
+name: test
+type: git
+repo: https://github.com/radareorg/r2pm
+desc: Test package for r2pm
+
+install: 
+  - true
+
+uninstall:
+  - true
+


### PR DESCRIPTION
Add the `-f <file>` option to the `install` command, which makes it possible to install an arbitrary package.