### PR TITLE
Make logging optional

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,6 +1,9 @@
 package features
 
 import (
+	"io/ioutil"
+	"log"
+	"os"
 	"regexp"
 
 	"golang.org/x/xerrors"
@@ -62,7 +65,7 @@ func Search(r2pmDir, pattern string) ([]r2package.Info, error) {
 		return nil, xerrors.Errorf("%q is not a valid regex: %w", pattern, err)
 	}
 
-	packages, err := ListInstalled(r2pmDir)
+	packages, err := ListAvailable(r2pmDir)
 	if err != nil {
 		return nil, xerrors.Errorf("could not get the list of packages: %w", err)
 	}
@@ -76,6 +79,14 @@ func Search(r2pmDir, pattern string) ([]r2package.Info, error) {
 	}
 
 	return matches, nil
+}
+
+func SetDebug(value bool) {
+	if value {
+		log.SetOutput(os.Stderr)
+	} else {
+		log.SetOutput(ioutil.Discard)
+	}
 }
 
 func Uninstall(r2pmDir, packageName string) error {

--- a/lib/main.go
+++ b/lib/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
 	"log"
-	"os"
 	"unsafe"
 
 	"github.com/radareorg/r2pm/internal/features"
@@ -25,6 +23,8 @@ const (
 func init() {
 	// Disable the logger by default
 	r2pm_set_debug(0)
+
+	log.SetPrefix("libr2pm: ")
 }
 
 func getReturnValue(err error) C.int {
@@ -105,15 +105,7 @@ func r2pm_uninstall(r2pmDir, packageName *C.char) C.int {
 
 //export r2pm_set_debug
 func r2pm_set_debug(value C.int) {
-	if value == 0 {
-		log.SetOutput(ioutil.Discard)
-		return
-	}
-
-	log.SetOutput(os.Stderr)
-	log.SetPrefix("libr2pm: ")
-
-	log.Print("debug enabled")
+	features.SetDebug(value != 0)
 }
 
 func main() {}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -51,16 +52,31 @@ func main() {
 			return err
 		}
 
-		log.Printf("%d available packages", len(packages))
+		fmt.Printf("%d available packages\n", len(packages))
 		printPackageSlice(packages)
 
 		return nil
 	}
 
+	const flagNameDebug = "debug"
+
 	app := cli.NewApp()
 	app.Name = "r2pm"
 	app.Usage = "r2 package manager"
 	app.Version = "0.0.1"
+
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:   flagNameDebug,
+			Usage:  "enable debug logs",
+			EnvVar: "R2PM_DEBUG",
+		},
+	}
+
+	app.Before = func(c *cli.Context) error {
+		features.SetDebug(c.Bool(flagNameDebug))
+		return nil
+	}
 
 	app.Commands = []cli.Command{
 		{
@@ -108,7 +124,7 @@ func main() {
 							return err
 						}
 
-						log.Printf("%d installed packages", len(packages))
+						fmt.Printf("%d installed packages\n", len(packages))
 						printPackageSlice(packages)
 
 						return nil
@@ -128,7 +144,7 @@ func main() {
 					return err
 				}
 
-				log.Printf("Your search returned %d matches", len(matches))
+				fmt.Printf("Your search returned %d matches\n", len(matches))
 				printPackageSlice(matches)
 
 				return nil
@@ -153,6 +169,6 @@ func main() {
 
 func printPackageSlice(packages []r2package.Info) {
 	for _, p := range packages {
-		log.Printf("%s: %s", p.Name, p.Desc)
+		fmt.Printf("%s: %s\n", p.Name, p.Desc)
 	}
 }

--- a/pkg/r2package/info.go
+++ b/pkg/r2package/info.go
@@ -1,6 +1,7 @@
 package r2package
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -96,7 +97,7 @@ func ReadDir(path string) ([]InfoFile, error) {
 
 		ifile, err := FromFile(name)
 		if err != nil {
-			log.Printf("could not read %s: %w", name, err)
+			fmt.Printf("Warning: could not read %s: %v", name, err)
 			continue
 		}
 


### PR DESCRIPTION
Logging can be enabled using the `--debug` flag or by setting `$R2PM_DEBUG` to `1` or `true`.