### PR TITLE
Enable logging in the library if $R2PM_DEBUG is set to true

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -16,7 +16,11 @@ import (
 	"github.com/radareorg/r2pm/pkg/site"
 )
 
-const msgCannotInitialize = "could not initialize: %w"
+const (
+	DebugEnvVar = "R2PM_DEBUG"
+
+	msgCannotInitialize = "could not initialize: %w"
+)
 
 func Delete(r2pmDir string) error {
 	s, err := site.New(r2pmDir)

--- a/lib/main.go
+++ b/lib/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"log"
+	"os"
+	"strconv"
 
 	"github.com/radareorg/r2pm/internal/features"
 )
@@ -22,10 +24,16 @@ const (
 )
 
 func init() {
-	// Disable the logger by default
-	r2pm_set_debug(0)
-
 	log.SetPrefix("libr2pm: ")
+
+	// Enable the logger if the environment variable is a valid boolean
+	env := os.Getenv(features.DebugEnvVar)
+
+	if val, err := strconv.ParseBool(env); err == nil && val {
+		r2pm_set_debug(1)
+	} else {
+		r2pm_set_debug(0)
+	}
 }
 
 func getReturnValue(err error) C.int {

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 		cli.BoolFlag{
 			Name:   flagNameDebug,
 			Usage:  "enable debug logs",
-			EnvVar: "R2PM_DEBUG",
+			EnvVar: features.DebugEnvVar,
 		},
 	}
 


### PR DESCRIPTION
This is available for both the Go binary and `libr2pm.so`.