### PR TITLE
Use build tags to group the UNIX code

### DIFF
--- a/internal/util/dir/dir_freebsd.go
+++ b/internal/util/dir/dir_freebsd.go
@@ -1,5 +1,0 @@
-package dir
-
-func platformPrefix() string {
-	return "/usr/local/share"
-}

--- a/internal/util/dir/dir_test_freebsd.go
+++ b/internal/util/dir/dir_test_freebsd.go
@@ -1,9 +1,0 @@
-package dir
-
-import "testing"
-
-func testSiteDir(t *testing.T) {
-	if s := SiteDir(); s != "/usr/local/share/RadareOrg/r2pm" {
-		t.Fatal(s)
-	}
-}

--- a/internal/util/dir/dir_test_unix.go
+++ b/internal/util/dir/dir_test_unix.go
@@ -1,3 +1,5 @@
+// +build darwin freebsd
+
 package dir
 
 import "testing"

--- a/internal/util/dir/dir_unix.go
+++ b/internal/util/dir/dir_unix.go
@@ -1,3 +1,5 @@
+// +build darwin freebsd
+
 package dir
 
 func platformPrefix() string {


### PR DESCRIPTION
Avoid code duplication.