### PR TITLE
fix info struct for new package format

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -15,6 +15,7 @@ A plugin file is a text file in the YAML format that contains various metadata a
 name: my-package  # must be unique and equals to the file name
 version: 1.2.3
 description: Some description   
+tags: [tag1, tag2]
 
 install:
 

--- a/main.go
+++ b/main.go
@@ -223,6 +223,6 @@ func main() {
 
 func printPackageSlice(packages []r2package.Info) {
 	for _, p := range packages {
-		fmt.Printf("%s: %s\n", p.Name, p.Desc)
+		fmt.Printf("%s: %s\n", p.Name, p.Description)
 	}
 }

--- a/pkg/r2package/git.go
+++ b/pkg/r2package/git.go
@@ -14,17 +14,17 @@ type gitInstaller struct {
 }
 
 func (g gitInstaller) install(inDir string) error {
-	const (
-		remoteName   = "origin"
-		remoteBranch = "master"
-	)
+	// TODO: don't hardcode Linux
+	platform := g.info.Install.Linux
+	remoteName := "origin"
+	remoteBranch := platform.Source.Ref
 
 	repo, err := git.Init(inDir, false)
 	if err != nil {
 		return fmt.Errorf("could not init the repository: %w", err)
 	}
 
-	if err := repo.AddRemote(remoteName, g.info.Repo); err != nil {
+	if err := repo.AddRemote(remoteName, platform.Source.Repo); err != nil {
 		return fmt.Errorf("could not add the remote: %w", err)
 	}
 
@@ -32,7 +32,7 @@ func (g gitInstaller) install(inDir string) error {
 		return fmt.Errorf("could not git pull: %w", err)
 	}
 
-	for idx, line := range g.info.InstallCmds {
+	for idx, line := range platform.Commands {
 		fields := strings.Fields(line)
 
 		cmd := exec.Command(fields[0], fields[1:]...)
@@ -51,7 +51,9 @@ func (g gitInstaller) install(inDir string) error {
 }
 
 func (g gitInstaller) uninstall(fromDir string) error {
-	for idx, line := range g.info.UninstallCmds {
+	// TODO: don't hardcode Linux
+	platform := g.info.Install.Linux
+	for idx, line := range platform.Commands {
 		fields := strings.Fields(line)
 
 		cmd := exec.Command(fields[0], fields[1:]...)

--- a/pkg/r2package/git.go
+++ b/pkg/r2package/git.go
@@ -14,8 +14,11 @@ type gitInstaller struct {
 }
 
 func (g gitInstaller) install(inDir string) error {
-	// TODO: don't hardcode Linux
-	platform := g.info.InstallConf.Linux
+	platform, err := g.info.InstallPlatform()
+	if err != nil {
+		return err
+	}
+
 	const remoteName = "origin"
 	remoteBranch := platform.Source.Ref
 
@@ -51,8 +54,11 @@ func (g gitInstaller) install(inDir string) error {
 }
 
 func (g gitInstaller) uninstall(fromDir string) error {
-	// TODO: don't hardcode Linux
-	platform := g.info.InstallConf.Linux
+	platform, err := g.info.InstallPlatform()
+	if err != nil {
+		return err
+	}
+
 	for idx, line := range platform.Commands {
 		fields := strings.Fields(line)
 

--- a/pkg/r2package/git.go
+++ b/pkg/r2package/git.go
@@ -16,7 +16,7 @@ type gitInstaller struct {
 func (g gitInstaller) install(inDir string) error {
 	// TODO: don't hardcode Linux
 	platform := g.info.Install.Linux
-	remoteName := "origin"
+	const remoteName = "origin"
 	remoteBranch := platform.Source.Ref
 
 	repo, err := git.Init(inDir, false)

--- a/pkg/r2package/git.go
+++ b/pkg/r2package/git.go
@@ -15,7 +15,7 @@ type gitInstaller struct {
 
 func (g gitInstaller) install(inDir string) error {
 	// TODO: don't hardcode Linux
-	platform := g.info.Install.Linux
+	platform := g.info.InstallConf.Linux
 	const remoteName = "origin"
 	remoteBranch := platform.Source.Ref
 
@@ -52,7 +52,7 @@ func (g gitInstaller) install(inDir string) error {
 
 func (g gitInstaller) uninstall(fromDir string) error {
 	// TODO: don't hardcode Linux
-	platform := g.info.Install.Linux
+	platform := g.info.InstallConf.Linux
 	for idx, line := range platform.Commands {
 		fields := strings.Fields(line)
 

--- a/pkg/r2package/info.go
+++ b/pkg/r2package/info.go
@@ -20,7 +20,7 @@ type OutputFile struct {
 	Type	string
 }
 
-// struct for each OS (e.g. Linux, Macos, Windows)
+// struct for each OS (e.g. Linux, MacOS, Windows)
 type Instructions struct {
 	Source struct {
 		Type	string
@@ -41,7 +41,7 @@ type Info struct {
 	InstallConf struct {
 		Linux	Instructions
 		Windows	Instructions
-		Macos	Instructions
+		MacOS	Instructions
 	} `yaml:"install"`
 	// TODO: uninstall
 }
@@ -55,7 +55,7 @@ func (i Info) InstallPlatform() (Instructions, error) {
 	case "windows":
 		return i.InstallConf.Windows, nil
 	case "darwin":
-		return i.InstallConf.Macos, nil
+		return i.InstallConf.MacOS, nil
 	default:
 		// can't return nil for the struct so just return Linux
 		return i.InstallConf.Linux, fmt.Errorf("Unsupported platform: %s",

--- a/pkg/r2package/info.go
+++ b/pkg/r2package/info.go
@@ -50,7 +50,7 @@ type Info struct {
 func (i Info) InstallPlatform() (Instructions, error) {
 	// return the Instructions struct corresponding to i.InstallConf.Platform
 	switch runtime.GOOS {
-	case "android", "freebsd", "linux", "netbsd", "openbsd":
+	case "linux":
 		return i.InstallConf.Linux, nil
 	case "windows":
 		return i.InstallConf.Windows, nil

--- a/pkg/r2package/info.go
+++ b/pkg/r2package/info.go
@@ -14,19 +14,47 @@ import (
 // Info
 //
 
+type OutputFile struct {
+	Path	string
+	Type	string
+}
+
 type Info struct {
-	Name          string
-	Version       string
-	Description   string
+	Name		string
+	Version		string
+	Description	string
+	Tags		[]string
 	// avoid conflict with i.Install()
 	InstallConf struct {
 		Linux struct {
 			Source struct {
-				Type    string
-				Repo    string
-				Ref     string
+				Type	string
+				Url	string	// for zip
+				Repo	string	// for git
+				Ref	string
 			}
 			Commands []string
+			Out []OutputFile `yaml:"out,flow"`	// for zip
+		}
+		Macos struct {
+			Source struct {
+				Type	string
+				Url	string
+				Repo	string
+				Ref	string
+			}
+			Commands []string
+			Out []OutputFile `yaml:"out,flow"`
+		}
+		Windows struct {
+			Source struct {
+				Type	string
+				Url	string
+				Repo	string
+				Ref	string
+			}
+			Commands []string
+			Out []OutputFile `yaml:"out,flow"`
 		}
 	} `yaml:"install"`
 	// TODO: windows, macos, uninstall, out, tags

--- a/pkg/r2package/info.go
+++ b/pkg/r2package/info.go
@@ -16,15 +16,22 @@ import (
 
 type Info struct {
 	Name          string
-	Type          string
-	Tags          []string
-	Repo          string
-	Desc          string
-	InstallCmds   []string `yaml:"install"`
-	UninstallCmds []string `yaml:"uninstall"`
+	Version       string
+	Description   string
+	Install struct {
+		Linux struct {
+			Source struct {
+				Type    string
+				Repo    string
+				Ref     string
+			}
+			Commands []string
+		}
+	}
+	// TODO: windows, macos, uninstall, out, tags
 }
 
-func (i Info) Install(inDir string) error {
+func (i Info) DoInstall(inDir string) error {
 	installer, err := i.installer()
 	if err != nil {
 		return err
@@ -33,7 +40,7 @@ func (i Info) Install(inDir string) error {
 	return installer.install(inDir)
 }
 
-func (i Info) Uninstall(inDir string) error {
+func (i Info) DoUninstall(inDir string) error {
 	installer, err := i.installer()
 	if err != nil {
 		return err
@@ -43,11 +50,15 @@ func (i Info) Uninstall(inDir string) error {
 }
 
 func (i Info) installer() (installer, error) {
-	switch i.Type {
+	// TODO: don't hardcode Linux
+	platform := i.Install.Linux
+	switch platform.Source.Type {
 	case "git":
 		return gitInstaller{i}, nil
+	// TODO: zip
 	default:
-		return nil, fmt.Errorf("%q: unhandled package type", i.Type)
+		return nil, fmt.Errorf("%q: unhandled package type",
+					platform.Source.Type)
 	}
 }
 

--- a/pkg/r2package/info.go
+++ b/pkg/r2package/info.go
@@ -18,7 +18,8 @@ type Info struct {
 	Name          string
 	Version       string
 	Description   string
-	Install struct {
+	// avoid conflict with i.Install()
+	InstallConf struct {
 		Linux struct {
 			Source struct {
 				Type    string
@@ -27,11 +28,11 @@ type Info struct {
 			}
 			Commands []string
 		}
-	}
+	} `yaml:"install"`
 	// TODO: windows, macos, uninstall, out, tags
 }
 
-func (i Info) DoInstall(inDir string) error {
+func (i Info) Install(inDir string) error {
 	installer, err := i.installer()
 	if err != nil {
 		return err
@@ -40,7 +41,7 @@ func (i Info) DoInstall(inDir string) error {
 	return installer.install(inDir)
 }
 
-func (i Info) DoUninstall(inDir string) error {
+func (i Info) Uninstall(inDir string) error {
 	installer, err := i.installer()
 	if err != nil {
 		return err
@@ -51,7 +52,7 @@ func (i Info) DoUninstall(inDir string) error {
 
 func (i Info) installer() (installer, error) {
 	// TODO: don't hardcode Linux
-	platform := i.Install.Linux
+	platform := i.InstallConf.Linux
 	switch platform.Source.Type {
 	case "git":
 		return gitInstaller{i}, nil

--- a/pkg/site/site.go
+++ b/pkg/site/site.go
@@ -70,7 +70,7 @@ func (s Site) UninstallPackage(name string) error {
 	}
 
 	// TODO: don't hardcode Linux
-	platform := ifile.Install.Linux
+	platform := ifile.InstallConf.Linux
 
 	dir, err := s.getPackageSubDir(platform.Source.Type)
 	if err != nil {
@@ -79,7 +79,7 @@ func (s Site) UninstallPackage(name string) error {
 
 	installedDir := filepath.Join(dir, ifile.Name)
 
-	if err := ifile.DoUninstall(installedDir); err != nil {
+	if err := ifile.Uninstall(installedDir); err != nil {
 		return fmt.Errorf("could not uninstall %s: %w", name, err)
 	}
 
@@ -156,7 +156,7 @@ func (s Site) gitSubDir() string {
 
 func (s Site) installFromInfoFile(ifile r2package.InfoFile) error {
 	// TODO: don't hardcode Linux
-	platform := ifile.Info.Install.Linux
+	platform := ifile.Info.InstallConf.Linux
 	dir, err := s.getPackageSubDir(platform.Source.Type)
 	if err != nil {
 		return fmt.Errorf("could not determine where to install %s: %w", ifile.Name, err)
@@ -168,7 +168,7 @@ func (s Site) installFromInfoFile(ifile r2package.InfoFile) error {
 		return fmt.Errorf("could not create %s: %w", dir, err)
 	}
 
-	if err := ifile.DoInstall(dir); err != nil {
+	if err := ifile.Install(dir); err != nil {
 		// delete the directory that we just created
 		os.RemoveAll(dir)
 

--- a/pkg/site/site.go
+++ b/pkg/site/site.go
@@ -69,8 +69,10 @@ func (s Site) UninstallPackage(name string) error {
 		return fmt.Errorf("could not find %s as an installed package", name)
 	}
 
-	// TODO: don't hardcode Linux
-	platform := ifile.InstallConf.Linux
+	platform, err := ifile.InstallPlatform()
+	if err != nil {
+		return err
+	}
 
 	dir, err := s.getPackageSubDir(platform.Source.Type)
 	if err != nil {
@@ -155,8 +157,11 @@ func (s Site) gitSubDir() string {
 }
 
 func (s Site) installFromInfoFile(ifile r2package.InfoFile) error {
-	// TODO: don't hardcode Linux
-	platform := ifile.Info.InstallConf.Linux
+	platform, err := ifile.Info.InstallPlatform()
+	if err != nil {
+		return err
+	}
+
 	dir, err := s.getPackageSubDir(platform.Source.Type)
 	if err != nil {
 		return fmt.Errorf("could not determine where to install %s: %w", ifile.Name, err)


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Most of this commit is just dealing with a rewritten Info struct to handle the new package format, which caused these other changes in the code:

  - temporarily hardcoded Linux as the platform until we have a function to decide that for us;
  - renamed Install() and Uninstall() as DoInstall() and DoUninstall() to avoid conflict with the Info.Install struct;
  - misc. small refactoring with changed Info structure.

@qbarrand, what do you think? This is my first time writing Go and contributing to this project so quite frankly I'm sure I screwed something up. I think my approach could be modified, perhaps, to fit in better with package.go? Not sure where you plan to go with that.

...

**Test plan**

A test package for r2dec-js installs with this YAML:
```yaml
---
name: r2dec-test
version: 0.0.0
description: "Converts asm to pseudo-C code. Test package for new format."

install:

  linux:
    source:
      type: git
      repo: https://github.com/radareorg/r2dec-js.git
      ref: master
    commands:
        - make -C p

# TODO: uninstall, windows, etc.
# TODO: {{ .Variable }} syntax parsing

# vim: ft=yaml sw=2:
```

...

**Closing issues**

None yet.

...
